### PR TITLE
Only execute rbenv-which if the result is used

### DIFF
--- a/bin/rbenv-env
+++ b/bin/rbenv-env
@@ -16,12 +16,10 @@ for script in $(rbenv-hooks exec); do
   source "$script"
 done
 
-RBENV_COMMAND="ruby"
-
-RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
-RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
-
 if [ "$RBENV_VERSION" != "system" ]; then
+  RBENV_COMMAND_PATH="$(rbenv-which ruby)"
+  RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
+
   export PATH="${RBENV_BIN_PATH}:${PATH}"
 fi
 


### PR DESCRIPTION
When testing the nodenv-env fork of this, I discovered that the rbenv-which command fails when a ruby version isn't set. Since the result of that command is only used when a ruby version is explicitly set, it doesn't make sense to attempt the command in all cases (especially when it fails in the negative case).

Related to https://github.com/rbenv/rbenv/issues/865
